### PR TITLE
Readme changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains visualisation of a [FLAME GPU 2](https://github.com/FLAMEGPU/FLAMEGPU2) implementation of the Circles agent based model at various population scales and densities.
 
-Extensive benchmarking of the same model is conducted in [https://github.com/FLAMEGPU/FLAMEGPU2-circles-benchmark](https://github.com/FLAMEGPU/FLAMEGPU2-circles-benchmark)
+Extensive benchmarking of the same model is conducted in [https://github.com/FLAMEGPU/FLAMEGPU2-circles-benchmark](https://github.com/FLAMEGPU/FLAMEGPU2-circles-benchmark).
 
 ## Benchmark Description and Results
 
@@ -10,7 +10,7 @@ There is a single experiment within this example which mean measures drift of th
 
 If the example is built with the CMAKE `VISUALISATION` flag then the experiment runs a single experimental configuration with a fixed communication radius.
 
-An example visualisation can be viewed on YouTube. 
+An example visualisation can be viewed [on YouTube](https://www.youtube.com/watch?v=ZedroqmOaHU).
 
 [![Circles model visualisation](https://img.youtube.com/vi/ZedroqmOaHU/0.jpg)](https://www.youtube.com/watch?v=ZedroqmOaHU)
 
@@ -21,20 +21,22 @@ The results below are from a RTX 2080 Ti.
 ### Drift Experiment
 
 + Communication Radius is varied between `1.0` and `5.0` with a  step of `1.0`
-+ Population size is fixed at 64,000
-+ Environment width is fixed at 40.0f
-+ The number of simulation steps is 3000
-+ 10 iterations are completed with unique seeds
- 
++ Population size is fixed at `64000`
++ Environment width is fixed at `40.0`
++ The number of simulation steps is `3000`
++ 10 simulations are completed with unique seeds for each communication radius
+
 [![Combined Figure](sample/figures/2080Ti-11.4-471.41/alpha.2-2080Ti-11.4-beltsoff/figure.png)](sample/figures/2080Ti-11.4-471.41/alpha.2-2080Ti-11.4-beltsoff/figure.png)
 
 ## Building and Running the Benchmark
 
-Detail of dependencies and the `cmake` build process are described in full in the [FLAMEGPU2-example-template Repo](https://github.com/FLAMEGPU/FLAMEGPU2-example-template) and are not repeated here. The benchmark should be built with seatbelts off (e.g. `-DSEATBELTS=OFF` passed to the `cmake` configuration step) to disable additional run-time checks and optionally disabling Python Swig support which is not needed for this model(-DBUILD_SWIG_PYTHON=OFF ). E.g. for Volta (`SM_70`) GPUs under Linux.
+Detail of dependencies and the `cmake` build process are described in full in the [FLAMEGPU2-example-template Repo](https://github.com/FLAMEGPU/FLAMEGPU2-example-template) and are not repeated here. The benchmark should be built with seatbelts off (e.g. `-DSEATBELTS=OFF` passed to the `cmake` configuration step) to disable additional run-time checks.
+
+For example, to build for Volta (`SM_70`) GPUs under Linux:
 
 ```bash
 # Configure 
-cmake . -B build -DCMAKE_BUILD_TYPE=Release -DSEATBELTS=OFF -DBUILD_SWIG_PYTHON=OFF -DCUDA_ARCH=70
+cmake . -B build -DCMAKE_BUILD_TYPE=Release -DSEATBELTS=OFF -DCUDA_ARCH=70
 # Build
 cmake --build build -j`nproc` 
 ```
@@ -45,10 +47,10 @@ cmake --build build -j`nproc`
 cd build
 ./bin/Release/circles-benchmarking-vis
 ```
+
 This will produce a number of `.csv` files in the `build` directory.
 
 Note: The `FLAMEGPU2_INC_DIR` environment variable may need to be set to `./_deps/flamegpu2-src/include/` for run-time compilation (RTC) to succeed if the source directory is not automatically found.
-
 
 ## Plotting Results
 


### PR DESCRIPTION
Makes several changes to improve the Readme

+ Additional markdown formatting
+ Reprhasing of the bullet around multiple repetitions of each comm radius
+ Removal of `-DBUILD_SWIG_PYTHON=OFF`. Off is the default value.
+ General markdown tweaks


